### PR TITLE
Improve current tests time

### DIFF
--- a/tests_time.py
+++ b/tests_time.py
@@ -57,11 +57,12 @@ class TestTimeFunctions(unittest.TestCase):
         log.debug(log_template.format('MCD: Euclides amb Bezout', n3, n4, res4, execute_time4))
 
         statics = (
-            "Time without Bezout:"
-            "   Lower Values:  {}"
-            "   Higher Values: {}"
-            "Time with Bezout:"
-            "   Lower Values:  {}"
-            "   Higher Values: {}"
+            "\n"
+            "Time without Bezout:\n"
+            "   Lower Values:  {}\n"
+            "   Higher Values: {}\n"
+            "Time with Bezout:\n"
+            "   Lower Values:  {}\n"
+            "   Higher Values: {}\n"
         )
         log.debug(statics.format(execute_time, execute_time2, execute_time3, execute_time4))

--- a/tests_time.py
+++ b/tests_time.py
@@ -23,8 +23,14 @@ class TestTimeFunctions(unittest.TestCase):
             "Time: {}\n"
         )
 
-        n1 = pow(2, 342)
-        n2 = pow(2, 442)
+        n1 = 45
+        n2 = 90
+
+        n3 = pow(2, 342)
+        n4 = pow(2, 442)
+
+        self.assertTrue(n3 > n1)
+        self.assertTrue(n4 > n2)
 
         res, execute_time = mw.generic_time_execution_check(
             MCD.euclid, n1, n2
@@ -37,3 +43,25 @@ class TestTimeFunctions(unittest.TestCase):
         )
 
         log.debug(log_template.format('MCD: Euclides amb Bezout', n1, n2, res2, execute_time2))
+
+        res3, execute_time3 = mw.generic_time_execution_check(
+            MCD.euclid, n3, n4
+        )
+
+        log.debug(log_template.format('MCD: Euclides Sense Bezout', n3, n4, res3, execute_time3))
+
+        res4, execute_time4 = mw.generic_time_execution_check(
+            MCD.bezout, n3, n4
+        )
+
+        log.debug(log_template.format('MCD: Euclides amb Bezout', n3, n4, res4, execute_time4))
+
+        statics = (
+            "Time without Bezout:"
+            "   Lower Values:  {}"
+            "   Higher Values: {}"
+            "Time with Bezout:"
+            "   Lower Values:  {}"
+            "   Higher Values: {}"
+        )
+        log.debug(statics.format(execute_time, execute_time2, execute_time3, execute_time4))

--- a/tests_time.py
+++ b/tests_time.py
@@ -65,4 +65,4 @@ class TestTimeFunctions(unittest.TestCase):
             "   Lower Values:  {}\n"
             "   Higher Values: {}\n"
         )
-        log.debug(statics.format(execute_time, execute_time2, execute_time3, execute_time4))
+        log.debug(statics.format(execute_time, execute_time3, execute_time2, execute_time4))


### PR DESCRIPTION
```vim
test_time_execution_over_euclid_mcd (tests_time.TestTimeFunctions) 
DEBUG:TestTimeFunctions.test_time_execution_over_euclid_mcd:
Method: MCD: Euclides Sense Bezout
N1: 45
N2: 90
Result: 45
Time: 1.1205673217773438e-05

DEBUG:TestTimeFunctions.test_time_execution_over_euclid_mcd:
Method: MCD: Euclides amb Bezout
N1: 45
N2: 90
Result: (45, 1, 0)
Time: 7.867813110351562e-06

DEBUG:TestTimeFunctions.test_time_execution_over_euclid_mcd:
Method: MCD: Euclides Sense Bezout
N1: 8.958978968711217e+102
N2: 1.1356855067118858e+133
Result: 8.958978968711217e+102
Time: 8.344650268554688e-06

DEBUG:TestTimeFunctions.test_time_execution_over_euclid_mcd:
Method: MCD: Euclides amb Bezout
N1: 8.958978968711217e+102
N2: 1.1356855067118858e+133
Result: (8.958978968711217e+102, 1.0, 0)
Time: 5.0067901611328125e-06

DEBUG:TestTimeFunctions.test_time_execution_over_euclid_mcd:
Time without Bezout:
   Lower Values:  1.1205673217773438e-05
   Higher Values: 8.344650268554688e-06
Time with Bezout:
   Lower Values:  7.867813110351562e-06
   Higher Values: 5.0067901611328125e-06

ok
```